### PR TITLE
Use Eudico binary instead of Lotus for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,6 @@ That being said, as the consensus layer is no longer storage-dependent, Spacenet
 
 > ⚠️ Support for storage-specific features in Spacenet is limited.
 
-### Using lotus Lite for Spacenet
-The Spacenet blockchain is growing fast in size! If you are looking to tinker a bit with the network and get some Spacenet FIL, but you are not planning to extensively use the network to the extent of running your own full-node, we have provided a read endpoint so you can interace with Spacenet through a Lotus Lite node.
-
-To connect to Spacenet through a Lotus Lite you need to configure `FULLNODE_API_INFO` to point to the following peer with the following `API_KEY`:
-```
-FULLNODE_API_INFO=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIl19.w1-vwONiteLN0VlD9ccNujoPBXoFjkJJRyYva0SHah4:/ip4/52.29.194.50/tcp/1234 ./lotus daemon --lite
-```
-To test that the connection has been successful you can try to create a new wallet and send some funds from the faucet. More info about Lotus Lite can be found  [here](https://lotus.filecoin.io/lotus/install/lotus-lite/)
-
-> 📓 We are only providing read access through our current Lotus Lite endpoint, if you would like to have write or admin access to a Spacenet full-node to test the network without having to sync your own node get in touch through this [Contact form](https://docs.google.com/forms/d/1O3_kHb2WJhil9sqXOxgGGGsqkAA61J1rKMfnb5os5yo/edit) or in FIL Slack's #spacenet.
-
-In future versions of Spacenet, we will provide periodic snapshot to help developers sync their full-nodes in a tractable amount of time. You can follow the progress of this feature in the [following issue](https://github.com/consensus-shipyard/spacenet/issues/18)
-
-
 ### Getting Spacenet FIL
 In order to fund your account with Spacenet FIL we provide a faucet at [https://spacenet.consensus.ninja](https://spacenet.consensus.ninja). Getting FIL is as simple as inputting your address in the textbox and clicking the button.
 - The per-request allowance given by the faucet is of 10 FIL.
@@ -65,34 +51,41 @@ If, for some reason, you require more Spacenet FIL for your application, feel fr
 ![](./assets/spacenet-faucet.png)
 
 ## Getting started for developers
-You can run a full-node and connect it to Spacenet by:
-- Cloning the modified lotus implementation for Spacenet:
+You can run a full-node and connect it to Spacenet by running eudico (a fork of lotus that is able to run several consensus algorithms):
+- Cloning the modified lotus implementation (eudico) for Spacenet:
 ```
 git clone https://github.com/consensus-shipyard/lotus
 
-// The latest stable branch for the network is `spacenet`
+// The default (and latest stable) branch for the network is `spacenet`
 git checkout spacenet
 ```
 - Installing lotus and running all dependencies as described in the `README` of the [repo](https://github.com/consensus-shipyard/lotus)
-- Once you have all `lotus` installed you can run the following command to compile `lotus` with Spacenet support.
+- Once you have all `lotus` dependencies installed you can run the following command to compile `eudico` with Spacenet support.
 ```
 make spacenet
 ```
 - With that, you are ready to run your spacenet daemon and connect to the network by connecting to any its bootstrap nodes.
 ```
-./lotus daemon --bootstrap=true
+./eudico mir daemon --bootstrap=true
 ```
-Spacenet supports every lotus command supported in mainnet, so you'll be able to configure your Spacenet full-node at will (by exposing a different API port, running Lotus lite, etc.). More info available in [Lotus' docs](https://lotus.filecoin.io/lotus/get-started/what-is-lotus/).
+Eudico in Spacenet supports every lotus command supported in mainnet, so you'll be able to configure your Spacenet full-node at will (by exposing a different API port, running Lotus lite, etc.). More info available in [Lotus' docs](https://lotus.filecoin.io/lotus/get-started/what-is-lotus/).
 
+### Using eudico Lite for Spacenet
+The Spacenet blockchain is growing fast in size! If you are looking to tinker a bit with the network and get some Spacenet FIL, but you are not planning to extensively use the network to the extent of running your own full-node, we have provided a read endpoint so you can interace with Spacenet through an Eudico Lite node.
+
+To connect to Spacenet through a Eudico Lite you need to configure `FULLNODE_API_INFO` to point to the following peer with the following `API_KEY`:
+```
+FULLNODE_API_INFO=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIl19.w1-vwONiteLN0VlD9ccNujoPBXoFjkJJRyYva0SHah4:/ip4/52.29.194.50/tcp/1234 ./eudico mir daemon --lite
+```
+To test that the connection has been successful you can try to create a new wallet and send some funds from the faucet. More info about Lotus/Eudico Lite can be found  [here](https://lotus.filecoin.io/lotus/install/lotus-lite/)
+
+> 📓 We are only providing read access through our current Eudico Lite endpoint, if you would like to have write or admin access to a Spacenet full-node to test the network without having to sync your own node get in touch through this [Contact form](https://docs.google.com/forms/d/1O3_kHb2WJhil9sqXOxgGGGsqkAA61J1rKMfnb5os5yo/edit) or in FIL Slack's #spacenet.
+
+In future versions of Spacenet, we will provide periodic snapshot to help developers sync their full-nodes in a tractable amount of time. You can follow the progress of this feature in the [following issue](https://github.com/consensus-shipyard/spacenet/issues/18)
 ## Getting started for validators
 
 > Support for external validators coming soon! Track the work in [the following issue](https://github.com/consensus-shipyard/lotus/issues/21). If you are interested in becoming a validator let us know through [this form](https://docs.google.com/forms/d/1O3_kHb2WJhil9sqXOxgGGGsqkAA61J1rKMfnb5os5yo).
 
 Spacenet is currently run by a committee of 4 validators owned by CL. We don't accept externally owned validators during this initial testing phase, until the network deployment is stabilized, but support for reconfiguration and external validators will be added soon.
-
-## What's next?
-- Reconfiguration.
-- FEVM.
-- Native WASM actors.
 
 

--- a/deployment/scripts/connect-daemon.sh
+++ b/deployment/scripts/connect-daemon.sh
@@ -4,6 +4,6 @@ cd lotus || exit
 
 while IFS="" read -r addr || [ -n "$addr" ]; do         # Read all lotus addresses from the provided file, liney by line
   if [ "$addr" != "$(cat ../.lotus/lotus-addr)" ]; then # Skip own address
-    ./lotus net connect "$addr" || exit                 # Connect to each other address
+    ./eudico net connect "$addr" || exit                 # Connect to each other address
   fi
 done < ../.lotus/lotus-addrs

--- a/deployment/scripts/generate-validator-identity.sh
+++ b/deployment/scripts/generate-validator-identity.sh
@@ -3,13 +3,13 @@
 cd lotus || exit
 
 # Create a new wallet to be used by the validator
-./lotus wallet new
+./eudico wallet new
 
 # Initialize a new configuration for the mir validator.
 # This will create mir-related config files in the $LOTUS_PATH directory.
-./mir-validator config init
+./eudico mir validator config init
 
 # Get the libp2p address of the local lotus node
-lotus_listen_addr=$(./mir-validator config validator-addr | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/')
+lotus_listen_addr=$(./eudico mir validator config validator-addr | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/')
 
 echo "${lotus_listen_addr}" > ~/.lotus/mir-validator-identity

--- a/deployment/scripts/kill.sh
+++ b/deployment/scripts/kill.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-killall lotus
+killall eudico
 killall mir-validator
 killall spacenet-faucet
 tmux kill-server
 
 sleep 3
 
-killall -9 lotus
+killall -9 eudico
 killall -9 mir-validator
 killall -9 spacenet-faucet
 tmux kill-server

--- a/deployment/scripts/start-bootstrap.sh
+++ b/deployment/scripts/start-bootstrap.sh
@@ -25,17 +25,17 @@ tmux new-session -d -s lotus
 
 # Start the Lotus daemon and import the bootstrap key.
 # Keeping the version with a custom genesis commented, in case we need to come back to it.
-#tmux send-keys "./lotus daemon --genesis=spacenet-genesis.car --profile=bootstrapper --bootstrap=false 2>&1" C-m
-tmux send-keys "./lotus daemon --profile=bootstrapper --bootstrap=false 2>&1 | ./rotate-logs.sh ${bootstrap_log_dir} ${log_file_lines} ${max_archive_size}" C-m
+#tmux send-keys "./eudico mir daemon --genesis=spacenet-genesis.car --profile=bootstrapper --bootstrap=false 2>&1" C-m
+tmux send-keys "./eudico mir daemon --profile=bootstrapper --bootstrap=false 2>&1 | ./rotate-logs.sh ${bootstrap_log_dir} ${log_file_lines} ${max_archive_size}" C-m
 mkdir -p ~/.lotus/keystore && chmod 0700 ~/.lotus/keystore
 ./lotus-shed keyinfo import spacenet-libp2p-bootstrap1.keyinfo
 echo '[Libp2p]
 ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]' > ~/.lotus/config.toml
-./lotus wait-api
-./lotus net listen | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/' > ~/.lotus/lotus-addr
+./eudico wait-api
+./eudico net listen | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/' > ~/.lotus/lotus-addr
 
 # Start the Faucet.
-./lotus wallet import --as-default --format=json-lotus spacenet_faucet.key
+./eudico wallet import --as-default --format=json-lotus spacenet_faucet.key
 cd ~/spacenet/faucet/ || exit
 go build -o spacenet-faucet ./cmd || exit
 tmux new-session -d -s faucet

--- a/deployment/scripts/start-bootstrap.sh
+++ b/deployment/scripts/start-bootstrap.sh
@@ -30,7 +30,12 @@ tmux send-keys "./eudico mir daemon --profile=bootstrapper --bootstrap=false 2>&
 mkdir -p ~/.lotus/keystore && chmod 0700 ~/.lotus/keystore
 ./lotus-shed keyinfo import spacenet-libp2p-bootstrap1.keyinfo
 echo '[Libp2p]
-ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]' > ~/.lotus/config.toml
+ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
+[Chainstore]
+  EnableSplitstore = true
+[Chainstore.Splitstore]
+  ColdStoreType = "discard"
+' > ~/.lotus/config.toml
 ./eudico wait-api
 ./eudico net listen | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/' > ~/.lotus/lotus-addr
 

--- a/deployment/scripts/start-daemon.sh
+++ b/deployment/scripts/start-daemon.sh
@@ -28,8 +28,8 @@ tmux new-session -d -s lotus
 
 # Start the Lotus daemon and import the bootstrap key.
 # Keeping the version with a custom genesis commented, in case we need to come back to it.
-#tmux send-keys "./lotus daemon --genesis=spacenet-genesis.car --bootstrap=true --mir-validator 2>&1" C-m
-tmux send-keys "./lotus daemon --bootstrap=true --mir-validator 2>&1 | ./rotate-logs.sh ${log_dir} ${log_file_lines} ${max_archive_size}" C-m
-./lotus wait-api
-./lotus net connect "$bootstrap_addr"
-./lotus net listen | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/' > ~/.lotus/lotus-addr
+#tmux send-keys "./eudico mir daemon --genesis=spacenet-genesis.car --bootstrap=true --mir-validator 2>&1" C-m
+tmux send-keys "./eudico mir daemon --bootstrap=true --mir-validator 2>&1 | ./rotate-logs.sh ${log_dir} ${log_file_lines} ${max_archive_size}" C-m
+./eudico wait-api
+./eudico net connect "$bootstrap_addr"
+./eudico net listen | grep -vE '(/ip6/)|(127.0.0.1)' | grep -E '/ip4/.*/tcp/' > ~/.lotus/lotus-addr

--- a/deployment/scripts/start-daemon.sh
+++ b/deployment/scripts/start-daemon.sh
@@ -22,6 +22,15 @@ cd lotus || exit
 log_dir=~/spacenet-logs/daemon-$(date +%Y-%m-%d-%H-%M-%S_%Z)
 mkdir -p "$log_dir"
 
+# Enable chainstore without discard
+# (discard is only enabled in bootstraps for now)
+mkdir -p ~/.lotus
+echo '[Libp2p]
+ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
+[Chainstore]
+  EnableSplitstore = true
+' > ~/.lotus/config.toml
+
 # Kill a potentially running instance of Lotus
 tmux kill-session -t lotus
 tmux new-session -d -s lotus

--- a/deployment/scripts/start-validator.sh
+++ b/deployment/scripts/start-validator.sh
@@ -21,4 +21,4 @@ tmux kill-session -t mir-validator
 tmux new-session -d -s mir-validator
 
 # Start the Mir validator.
-tmux send-keys "./mir-validator run --nosync 2>&1 | ./rotate-logs.sh ${log_dir} ${log_file_lines} ${max_archive_size}" C-m
+tmux send-keys "./eudico mir validator run --nosync 2>&1 | ./rotate-logs.sh ${log_dir} ${log_file_lines} ${max_archive_size}" C-m

--- a/deployment/spacenet_template.json
+++ b/deployment/spacenet_template.json
@@ -1,5 +1,5 @@
 {
-  "NetworkVersion": 17,
+  "NetworkVersion": 18,
   "Accounts": [
     {
       "Type": "account",


### PR DESCRIPTION
_Do not merge until it has been tested in the Spacenet network restart_

This PR:
- Updates deployment scripts to use `eudico` instead of `lotus` and use `eudico mir validator` instead of `mir-validator`.
- Updates README and tutorials accordingly.
- Upgrades the genesis template network version.
- Enable splitstore in validators and bootstraps