### PR TITLE
Add update-faucet playbook

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -224,6 +224,16 @@ Assumes that the Lotus daemons are up and running (see start-daemons.yaml).
 
 Applies to the validator host by default, unless other nodes are specified using --extra-vars "nodes=..."
 
+### `stop-monitoring.yaml`
+
+Stops the health monitoring services.
+Assumes that all the health services are running on the target nodes (bootstraps, daemons, and validators).
+
+### `update-faucet.yaml`
+
+Updates the faucet services by pulling the actual code from the repository.
+It doesn't recompile or start services.
+
 ### `update-nodes.yaml`
 
 Updates a given set of validators by fetching the configured code, recompiling it, and restarting the validators.

--- a/deployment/stop-monitoring.yaml
+++ b/deployment/stop-monitoring.yaml
@@ -10,5 +10,5 @@
   tasks:
 
     - name: Stop monitoring service
-      shell: "killall spacenet-health; sleep 3; killall -9 spacenet-health; true"
+      shell: "killall spacenet-health; sleep 3; killall -9 spacenet-health; true; tmux kill-session -t health"
 ...

--- a/deployment/stop-monitoring.yaml
+++ b/deployment/stop-monitoring.yaml
@@ -10,5 +10,5 @@
   tasks:
 
     - name: Stop monitoring service
-      shell: "killall spacenet-health; sleep 3; killall -9 spacenet-health; true; tmux kill-session -t health"
+      shell: "killall spacenet-health; sleep 3; killall -9 spacenet-health; tmux kill-session -t health; true"
 ...

--- a/deployment/update-faucet.yaml
+++ b/deployment/update-faucet.yaml
@@ -1,0 +1,22 @@
+# Updates the faucet repo.
+# This script suggests that the environment for the faucet and monitoring is ready
+# and contains all dependencies.
+
+---
+- name: Update Faucet
+  hosts: "{{nodes | default('all')}}"
+  gather_facts: False
+  become: False
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/home/{{ ansible_user }}/go/bin"
+  tasks:
+
+    - name: "Pull from git: {{ spacenet_git_version }}"
+      ansible.builtin.git:
+        repo: "{{ spacenet_git_repo }}"
+        dest: ~/spacenet
+        single_branch: True
+        version: "{{ spacenet_git_version }}"
+        force: True
+        update: True
+...


### PR DESCRIPTION
This PR adds a playbook to update the faucet repo.

Then we can run the following to update the monitoring systems:
```
ansible-playbook ... stop-monitoring.yaml
ansible-playbook ... update-faucet.yaml
ansible-playbook ... start-monitoring.yaml
```